### PR TITLE
fix: use i18n methods and remove prefix for default locale

### DIFF
--- a/components/Intro/Logo.vue
+++ b/components/Intro/Logo.vue
@@ -13,10 +13,11 @@
 const { locale } = useI18n();
 const logo = ref(null);
 const router = useRouter();
+const localePath = useLocalePath();
 
 onMounted(() => {
    setTimeout(() => {
-      router.push({ path: `/${locale.value}/introduction` });
+      router.push({ path: localePath(`introduction`) });
    }, 3000);
 });
 </script>

--- a/components/transactions/list-view/Item.vue
+++ b/components/transactions/list-view/Item.vue
@@ -61,6 +61,7 @@
 <script setup lang="ts">
 import { PhCheckCircle, PhClock, PhCaretRight } from "@phosphor-icons/vue";
 const { formatCurrency } = useFormatNumber();
+const { locale } = useI18n();
 
 defineProps({
    transaction: {
@@ -70,7 +71,7 @@ defineProps({
 });
 
 function getMonth(date: Date) {
-   return date.toLocaleDateString("en-US", { month: "short" });
+   return date.toLocaleDateString(locale.value, { month: "short" });
 }
 
 function getYear(date: Date) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,7 +16,7 @@ export default defineNuxtConfig({
 
    i18n: {
       locales: ["en-US", "nl-NL"],
-      strategy: "prefix",
+      strategy: "prefix_except_default",
       defaultLocale: "en-US",
       detectBrowserLanguage: false,
       vueI18n: "./i18n.config.ts",


### PR DESCRIPTION
Remove the en-US prefix because it's the default. Fix some parts that don't utilize the nuxt-i18n